### PR TITLE
Update to wildbit/postmark-php 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"php": ">=5.5",
 		"silverstripe/framework": "^3.1",
-		"wildbit/postmark-php": "^1.3"
+		"wildbit/postmark-php": "^2.5"
 	},
 	"extra": {
 		"installer-name": "postmark-mailer"


### PR DESCRIPTION
I had conflicts with other modules using `guzzlehttp/guzzle: ~6.0`

Looking at the changes everything seems backward-compatible (besides the PHP version bump), and I’ve not encountered any issues yet: https://github.com/wildbit/postmark-php/compare/1.3.2...2.5.0

